### PR TITLE
Allow outcome.name to be NULL for one-sided formulas

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# formulaic 0.0.9
+
+### New features:
+* create.formula: Added support for one-sided formulas by setting `outcome.name = NULL`. One-sided formulas (e.g., `~ x1 + x2`) are used by many R functions including `xtabs()`, `model.matrix()`, `matchit()`, `weightit()`, `cor.test()`, `pairs()`, and others.
+
+### Documentation:
+* Added one-sided formula examples to README
+* Added "One-Sided Formulas" section to package vignette
+* Updated `outcome.name` parameter documentation
+
 # formulaic 0.0.8
 
 

--- a/R/create.formula.R
+++ b/R/create.formula.R
@@ -2,7 +2,7 @@
 #'
 #' Create formula is a tool to automatically create a formula object from a provided variable and output names. Reduces the time required to manually input variables for modeling. Output can be used in linear regression, random forest, neural network etc. Create formula becomes useful when modeling data with multiple features. Reduces the time required for modeling and implementation :
 
-#' @param outcome.name A character value specifying the name of the formula's outcome variable. In this version, only a single outcome may be ed. The first entry of outcome.name will be used to build the formula.
+#' @param outcome.name A character value specifying the name of the formula's outcome variable. In this version, only a single outcome may be ed. The first entry of outcome.name will be used to build the formula. When NULL, a one-sided formula is created (e.g., ~ x1 + x2), which is useful for functions like xtabs(), model.matrix(), matchit(), and others that accept one-sided formulas.
 #' @param input.names The names of the variables with the full names delineated. User can specify '.' or 'all' to e all the column variables.
 #' @param input.patterns es additional input variables. The user may enter patterns -- e.g. to e every variable with a name that es the pattern. Multiple patterns may be ed as a character vector. However, each pattern may not contain spaces and is otherwise subject to the same limits on patterns as used in the grep function.
 #' @param dat User can specify a data.frame object that will be used to remove any variables that are not listed in names(dat. As default it is set as NULL. In this case, the formula is created simply from the outcome.name and input.names.
@@ -29,12 +29,15 @@
 #'  dd[, y := 5 * x + 3 * pixel_1 + 2 * pixel_2 + rnorm(n)]
 #'
 #'  create.formula(outcome.name = "y", input.names = "x", input.patterns = c("pi", "xel"), dat = dd)
+#'
+#'  # One-sided formula (useful for xtabs, model.matrix, matchit, etc.)
+#'  create.formula(outcome.name = NULL, input.names = c("x", "w"), dat = dd)
 #' @import stats
 #' @import data.table
 #' @export
 #'
 create.formula <-
-  function(outcome.name,
+  function(outcome.name = NULL,
            input.names = NULL,
            input.patterns = NULL,
            dat = NULL,
@@ -68,21 +71,25 @@ create.formula <-
     interactions <- unique(interactions)
     input.patterns <- unique(input.patterns)
 
-    outcome.name <- outcome.name[1]
+    if (!is.null(outcome.name)) {
+      outcome.name <- outcome.name[1]
+    }
 
     if (is.data.frame(dat)) {
 
       original.format.dt <- is.data.table(x = dat)
       data.table::setDT(dat)
 
+      unique.outcome.values <- NULL
+      if (!is.null(outcome.name)) {
+        statement.outcome.values <- sprintf("dat[, unique(%s)]", add.backtick(x = outcome.name, include.backtick = "as.needed", dat = dat))
 
-      statement.outcome.values <- sprintf("dat[, unique(%s)]", add.backtick(x = outcome.name, include.backtick = "as.needed", dat = dat))
+        unique.outcome.values <- tryCatch(expr = eval(expr = parse(text = statement.outcome.values)), error = function(e) return(NULL))
 
-      unique.outcome.values <- tryCatch(expr = eval(expr = parse(text = statement.outcome.values)), error = function(e) return(NULL))
-
-      if (is.null(unique.outcome.values)){
-        stop("To create a formula, the outcome.name must be a quantity that can be calculated from the variables in dat."
-        )
+        if (is.null(unique.outcome.values)){
+          stop("To create a formula, the outcome.name must be a quantity that can be calculated from the variables in dat."
+          )
+        }
       }
 
 
@@ -206,19 +213,26 @@ create.formula <-
 
       inclusion.table[exclude.null.quantity == F, exclude.user.specified := variable %in% variable.names.from.exclude]
       #inclusion.table[, exclude.not.in.names.dat := !(variable %in% names(dat))]
-      inclusion.table[, exclude.matches.outcome.name := (variable == outcome.name)]
+      if (!is.null(outcome.name)) {
+        inclusion.table[, exclude.matches.outcome.name := (variable == outcome.name)]
+      } else {
+        inclusion.table[, exclude.matches.outcome.name := FALSE]
+      }
 
       if (reduce == TRUE) {
-        num.outcome.categories <- length(unique.outcome.values[!is.na(unique.outcome.values)])
+        if (!is.null(outcome.name)) {
+          num.outcome.categories <- length(unique.outcome.values[!is.na(unique.outcome.values)])
+        } else {
+          num.outcome.categories <- 0
+        }
 
         the.inputs <-
           inclusion.table[exclude.null.quantity == F, variable]
 
-        if (num.outcome.categories <= max.outcome.categories.to.search) {
+        if (!is.null(outcome.name) && num.outcome.categories <= max.outcome.categories.to.search) {
 
           by.step.num.unique <- sprintf("%s", add.backtick(x = outcome.name, dat = dat))
-        }
-        if (num.outcome.categories > max.outcome.categories.to.search) {
+        } else {
           by.step.num.unique <- "NULL"
         }
 
@@ -233,14 +247,17 @@ create.formula <-
 
         melted.num.unique.tab <- rbindlist(l = list.num.unique)
 
-        if(outcome.name %in% names(melted.num.unique.tab) == FALSE){
-          melted.num.unique.tab[, eval(outcome.name) := "All"]
+        # Use a placeholder column name for one-sided formulas (outcome.name = NULL)
+        outcome.col.name <- if (!is.null(outcome.name)) outcome.name else ".outcome.placeholder"
+
+        if(outcome.col.name %in% names(melted.num.unique.tab) == FALSE){
+          melted.num.unique.tab[, eval(outcome.col.name) := "All"]
         }
 
-        setnames(x = melted.num.unique.tab, old = outcome.name, new = "V1")
+        setnames(x = melted.num.unique.tab, old = outcome.col.name, new = "V1")
         num.unique.tab <- dcast.data.table(data = melted.num.unique.tab, formula = V1 ~ input, value.var = "num.unique")
 
-        setnames(x = num.unique.tab, old = "V1", new = outcome.name)
+        setnames(x = num.unique.tab, old = "V1", new = outcome.col.name)
 
         min.categories.tab <-
           num.unique.tab[, .(variable = the.inputs,
@@ -366,9 +383,6 @@ create.formula <-
     input.names.delineated <-
       add.backtick(x =  all.input.names, include.backtick = include.backtick, dat = dat)
 
-    outcome.name.delineated <-
-      add.backtick(x = outcome.name, include.backtick = include.backtick, dat = dat)
-
     rhs.with.missing <- c(input.names.delineated, interaction.terms)
     rhs <- rhs.with.missing[!is.na(rhs.with.missing)]
 
@@ -376,8 +390,16 @@ create.formula <-
       rhs <- "1"
     }
 
-    the.formula <-
-      sprintf("%s ~ %s", outcome.name.delineated, paste(rhs, collapse = " + "))
+    # Create one-sided formula when outcome.name is NULL
+    if (!is.null(outcome.name)) {
+      outcome.name.delineated <-
+        add.backtick(x = outcome.name, include.backtick = include.backtick, dat = dat)
+      the.formula <-
+        sprintf("%s ~ %s", outcome.name.delineated, paste(rhs, collapse = " + "))
+    } else {
+      the.formula <-
+        sprintf("~ %s", paste(rhs, collapse = " + "))
+    }
 
     if (include.intercept == FALSE) {
       the.formula <- sprintf("%s - 1", the.formula)

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ formula1 <- create.formula(outcome.name = "y", input.names = c("x","Random error
 formula1$formula
 y ~ x + pixel_1 + `pixel 2` + pixel_3
 ```
-The result is a formula object of all the pixel variables and the input x. Notice that the 'Random error' variable was automatically excluded from the output, and a backtick was automatically added to the variable pixel 2. Since the independent variable y was included as a feature, it was excluded from the output formula. 
+The result is a formula object of all the pixel variables and the input x. Notice that the 'Random error' variable was automatically excluded from the output, and a backtick was automatically added to the variable pixel 2. Since the independent variable y was included as a feature, it was excluded from the output formula.
 
-Details of the variables included are provided in the inclusion table 
+Details of the variables included are provided in the inclusion table
 
-```r 
+```r
 # inclustion table
 > formula1$inclusion.table
        variable   class order specified.from exclude.user.specified exclude.not.in.names.dat exclude.matches.outcome.name include.variable
@@ -92,6 +92,24 @@ Details of the variables included are provided in the inclusion table
 
 # implement formula object
 model <- lm(formula = formula1, data = dd)
+```
+
+### One-Sided Formulas
+
+One-sided formulas (without a left-hand side) are used by many R functions including `xtabs()`, `model.matrix()`, `matchit()`, `weightit()`, `cor.test()`, and others. Create one-sided formulas by setting `outcome.name = NULL`:
+
+``` r
+# create a one-sided formula
+one.sided <- create.formula(outcome.name = NULL, input.names = c("x", "w"), dat = dd)
+
+one.sided$formula
+~ x + w
+
+# useful for functions like xtabs
+xtabs(one.sided$formula, data = dd)
+
+# or model.matrix
+model.matrix(one.sided$formula, data = dd)
 ```
 
 

--- a/tests/testthat/test-create_formula.R
+++ b/tests/testthat/test-create_formula.R
@@ -110,3 +110,76 @@ test_that(
       Gender
   )
 )
+
+# ---------------------------------
+# One-sided formula tests (outcome.name = NULL)
+
+test_that('one-sided formula with input.names', {
+  one.sided.1 <- formulaic::create.formula(
+    outcome.name = NULL,
+    input.names = c("x", "w"),
+    dat = dd
+  )
+  expect_equal(one.sided.1$formula, ~ x + w)
+  expect_s3_class(one.sided.1$formula, "formula")
+})
+
+test_that('one-sided formula with input.patterns', {
+  one.sided.2 <- formulaic::create.formula(
+    outcome.name = NULL,
+    input.patterns = "pix",
+    dat = dd
+  )
+  expect_equal(one.sided.2$formula, ~ pixel_1 + `pixel 2` + pixel_3)
+})
+
+test_that('one-sided formula without dat', {
+  one.sided.3 <- formulaic::create.formula(
+    outcome.name = NULL,
+    input.names = c("a", "b", "c")
+  )
+  expect_equal(one.sided.3$formula, ~ a + b + c)
+})
+
+test_that('one-sided formula with interactions', {
+  one.sided.4 <- formulaic::create.formula(
+    outcome.name = NULL,
+    input.names = c("x", "w"),
+    interactions = list(c("x", "w")),
+    dat = dd
+  )
+  expect_equal(one.sided.4$formula, ~ x + w + x * w)
+})
+
+test_that('one-sided formula with include.intercept = FALSE', {
+  one.sided.5 <- formulaic::create.formula(
+    outcome.name = NULL,
+    input.names = c("x", "w"),
+    dat = dd,
+    include.intercept = FALSE
+  )
+  expect_equal(one.sided.5$formula, ~ x + w - 1)
+})
+
+test_that('one-sided formula with reduce = TRUE', {
+  one.sided.6 <- formulaic::create.formula(
+    outcome.name = NULL,
+    input.names = c("x", "w", "pixel_1"),
+    dat = dd,
+    reduce = TRUE
+  )
+  expect_s3_class(one.sided.6$formula, "formula")
+  # All variables should be included since they have contrast
+  expect_true("x" %in% all.vars(one.sided.6$formula))
+})
+
+test_that('one-sided formula with . for all columns', {
+  one.sided.7 <- formulaic::create.formula(
+    outcome.name = NULL,
+    input.names = '.',
+    dat = dd
+  )
+  # Should include all columns from dd
+  expect_s3_class(one.sided.7$formula, "formula")
+  expect_true(length(all.vars(one.sided.7$formula)) == ncol(dd))
+})

--- a/vignettes/Introduction-to-formulaic.Rmd
+++ b/vignettes/Introduction-to-formulaic.Rmd
@@ -114,6 +114,45 @@ user.input.names <- c('Age Group', 'Gender', 'Region')
 create.formula(outcome.name = user.outcome.name, input.names = user.input.names)$formula
 ```
 
+## One-Sided Formulas
+
+One-sided formulas (without a left-hand side outcome variable) are used by many R functions including `xtabs()`, `model.matrix()`, `matchit()`, `weightit()`, `cor.test()`, `pairs()`, and others. The `create.formula` function supports one-sided formulas by setting `outcome.name = NULL`:
+
+```{r one-sided formula example}
+# Create a one-sided formula
+one.sided.form <- create.formula(
+  outcome.name = NULL,
+  input.names = c("Age", "Gender", "Region"),
+  dat = snack.dat
+)
+
+one.sided.form$formula
+```
+
+One-sided formulas can also use patterns and interactions:
+
+```{r one-sided formula with patterns}
+# One-sided formula with patterns
+one.sided.bp <- create.formula(
+  outcome.name = NULL,
+  input.patterns = "BP_",
+  dat = snack.dat
+)
+
+one.sided.bp$formula
+```
+
+```{r one-sided formula usage}
+# Example usage with xtabs
+xtabs.form <- create.formula(
+  outcome.name = NULL,
+  input.names = c("Gender", "Region"),
+  dat = snack.dat
+)
+
+xtabs(xtabs.form$formula, data = snack.dat)
+```
+
 
 ## Dataset (snack.dat)
  
@@ -190,7 +229,7 @@ The create.formula function is designed to automatically generate formulas from 
 
 ### Parameter description:
 
-- **outcome.name** A character value specifying the name of the formula's outcome variable.  In this version, only a single outcome may be included.  The first entry of outcome.name will be used to build the formula.
+- **outcome.name** A character value specifying the name of the formula's outcome variable.  In this version, only a single outcome may be included.  The first entry of outcome.name will be used to build the formula. When set to NULL, a one-sided formula is created (e.g., ~ x1 + x2), which is useful for functions like xtabs(), model.matrix(), matchit(), and others that accept one-sided formulas.
 
 - **input.names** The names of the variables with the full names delineated.
  


### PR DESCRIPTION
One-sided formulas (e.g., ~ x1 + x2) are commonly used by functions like
xtabs(), model.matrix(), matchit(), weightit(), cor.test(), and many
others. This change allows create.formula() to produce one-sided formulas
by passing outcome.name = NULL.

Changes:
- Set outcome.name default to NULL in function signature
- Skip outcome validation when outcome.name is NULL
- Create one-sided formula format when outcome.name is NULL
- Handle NULL outcome in reduce logic with placeholder column name
- Add documentation and example for one-sided formula usage
- Add comprehensive tests for one-sided formula creation